### PR TITLE
Fix: GitHub Pages base and SPA fallback (add CI/CD)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy Vite app to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/404.html
+++ b/404.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Split-Merge</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/split-merge/',
   plugins: [react()],
 })


### PR DESCRIPTION
Fixes #5 

## Changes
- Set Vite `base` to `/split-merge/` so assets resolve under the project Pages URL.
- Added `404.html` fallback (serves SPA shell for unknown paths).
- Added GitHub Actions workflow to build (`npm ci && npm run build`) and deploy `dist/` to GitHub Pages.

## Reasoning
- GitHub Pages project sites serve under `/<repo>/`; Vite’s default `base: '/'` breaks asset paths.
- Static hosts return 404 on non-existent paths; a `404.html` that mirrors `index.html` ensures the SPA loads.
- CI/CD demonstrates professional workflow, avoids committing build artifacts, and auto-deploys on merge.

## Verification (local)
- `npm run build && npm run preview` loads the app without 404s.

## Post-merge checklist
- Confirm repo **Settings → Pages → Source = GitHub Actions**.
- Wait for the `Deploy Vite app to GitHub Pages` workflow to complete.
- Visit: https://danny-mendoza1.github.io/split-merge/
- Hard refresh (Ctrl/Cmd+Shift+R). Validate:
  - App loads, assets resolve.
  - Refreshing the root (and any future routes) does not 404.
- Move Issue and Project card to **Done**.
